### PR TITLE
cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ install(
 # Install cmake scripts
 install(
     DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/cmake/"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/dlplan"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/dlplan/cmake"
 )
 
 ###########

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/configure_boost.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/configure_boost.cmake")
 
 ##############
 # Dependencies

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/cmake/configure_boost.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/configure_boost.cmake")
 
 ##############
 # Dependencies


### PR DESCRIPTION
After trying [3.1](https://github.com/rleap-project/dlplan#31-building-the-c-interface) and attempting to build my project, I get the following error:

```
CMake Error at ext/dlplan/lib/cmake/dlplan/dlplanConfig.cmake:17 (include):
  include could not find requested file:

    /home/dillon/code/lineplan/planners/downward/src/ext/dlplan/lib/cmake/dlplan/cmake/configure_boost.cmake
Call Stack (most recent call first):
  search/CMakeLists.txt:36 (find_package)


CMake Error at ext/dlplan/lib/cmake/dlplan/dlplanConfig.cmake:25 (configure_boost):
  Unknown CMake command "configure_boost".
Call Stack (most recent call first):
  search/CMakeLists.txt:36 (find_package)
```

This seems to be fixed by changing the include path in `Config.cmake.in`