### PR TITLE
Build package for python 3.{9,10,11,12,13}

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 
 [tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-*"
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 archs = "auto64"
 container-engine = "docker"
 manylinux-x86_64-image = "manylinux2014"


### PR DESCRIPTION
Provide wheels for newer python versions so downstream projects do not need to build dlplan from scratch.

Remove python 3.8, as it's EOL.