### PR TITLE
Optionally silence logger with environment variable

### DIFF
--- a/src/generator/generator_data.h
+++ b/src/generator/generator_data.h
@@ -50,10 +50,10 @@ struct GeneratorData {
     }
 
     void print_statistics() const {
-        std::cout << "Total concept elements: " << std::accumulate(m_concepts_by_iteration.begin(), m_concepts_by_iteration.end(), 0, [&](int current_sum, const auto& e){ return current_sum + e.size(); }) << std::endl
-                  << "Total role elements: " << std::accumulate(m_roles_by_iteration.begin(), m_roles_by_iteration.end(), 0, [&](int current_sum, const auto& e){ return current_sum + e.size(); }) << std::endl
-                  << "Total numerical elements: " << std::accumulate(m_numericals_by_iteration.begin(), m_numericals_by_iteration.end(), 0, [&](int current_sum, const auto& e){ return current_sum + e.size(); }) << std::endl
-                  << "Total boolean elements: " << std::accumulate(m_booleans_by_iteration.begin(), m_booleans_by_iteration.end(), 0, [&](int current_sum, const auto& e){ return current_sum + e.size(); }) << std::endl;
+      utils::g_log << "Total concept elements: " << std::accumulate(m_concepts_by_iteration.begin(), m_concepts_by_iteration.end(), 0, [&](int current_sum, const auto& e){ return current_sum + e.size(); }) << std::endl
+                   << "Total role elements: " << std::accumulate(m_roles_by_iteration.begin(), m_roles_by_iteration.end(), 0, [&](int current_sum, const auto& e){ return current_sum + e.size(); }) << std::endl
+                   << "Total numerical elements: " << std::accumulate(m_numericals_by_iteration.begin(), m_numericals_by_iteration.end(), 0, [&](int current_sum, const auto& e){ return current_sum + e.size(); }) << std::endl
+                   << "Total boolean elements: " << std::accumulate(m_booleans_by_iteration.begin(), m_booleans_by_iteration.end(), 0, [&](int current_sum, const auto& e){ return current_sum + e.size(); }) << std::endl;
     }
 
     bool reached_resource_limit() {

--- a/src/generator/rules/rule.h
+++ b/src/generator/rules/rule.h
@@ -2,6 +2,7 @@
 #define DLPLAN_SRC_GENERATOR_FEATURE_GENERATOR_RULES_RULE_H_
 
 #include "../../../include/dlplan/core.h"
+#include "../../../src/utils/logging.h"
 
 #include <string>
 #include <iostream>
@@ -45,7 +46,7 @@ public:
 
     void print_statistics() const {
         if (m_enabled) {
-            std::cout << "    " << get_name() << ": " << m_count << std::endl;
+          utils::g_log << "    " << get_name() << ": " << m_count << std::endl;
         }
     }
 

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -1,7 +1,9 @@
 #include "logging.h"
 
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
+#include <string>
 #include <vector>
 
 using namespace std;
@@ -9,5 +11,13 @@ using namespace std;
 namespace dlplan::utils {
 
 Log g_log;
+
+Log::Log() {
+    // Silence the logger if the environment variable is set to 1.
+    const char *env_silent = getenv("DLPLAN_SILENT_LOG");
+    if (env_silent && string(env_silent) == "1") {
+        silent = true;
+    }
+}
 
 }

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -26,10 +26,14 @@ namespace dlplan::utils {
 class Log {
 private:
     bool line_has_started = false;
+    const bool silent = true;
 
 public:
     template<typename T>
     Log &operator<<(const T &elem) {
+        if (silent) {
+          return *this;
+        }
         if (!line_has_started) {
             line_has_started = true;
             std::cout << "[t=" << g_timer << ", "
@@ -44,6 +48,9 @@ public:
     Log &operator<<(manip_function f) {
         if (f == static_cast<manip_function>(&std::endl)) {
             line_has_started = false;
+        }
+        if (silent) {
+          return *this;
         }
 
         std::cout << f;

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -26,9 +26,10 @@ namespace dlplan::utils {
 class Log {
 private:
     bool line_has_started = false;
-    const bool silent = true;
+    bool silent = false;
 
 public:
+    Log();
     template<typename T>
     Log &operator<<(const T &elem) {
         if (silent) {
@@ -46,13 +47,12 @@ public:
 
     using manip_function = std::ostream &(*)(std::ostream &);
     Log &operator<<(manip_function f) {
+        if (silent) {
+            return *this;
+        }
         if (f == static_cast<manip_function>(&std::endl)) {
             line_has_started = false;
         }
-        if (silent) {
-          return *this;
-        }
-
         std::cout << f;
         return *this;
     }


### PR DESCRIPTION
Optionally silence the logger if the environment variable `DLPLAN_SILENT_LOGGER` is set to 1.

This is useful if dlplan is used as a library in other applications, where it may be called repeatedly (e.g., in [genfond](https://github.com/morxa/genfond), we call the feature generator many times). In this case, the log output is overly verbose and it's better to have no log messages at all.